### PR TITLE
python-iso639 2024.4.27 :snowflake:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,32 +10,40 @@ source:
   sha256: 97e63b5603e085c6a56a12a95740010e75d9134e0aab767e0978b53fd8824f13
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - setuptools >=65.3.0
     - wheel
     - pip
   run:
-    - python >=3.8
+    - python
 
 test:
   imports:
     - iso639
   commands:
     - pip check
+  source_files:
+    - tests
   requires:
     - pip
 
 about:
-  summary: Look-up utilities for ISO 639 language codes and names
   home: https://github.com/jacksonllee/iso639
   license: Apache-2.0
   license_file: LICENSE.txt
+  license_family: Apache
+  summary: Look-up utilities for ISO 639 language codes and names
+  description: |
+    python-iso639 is a Python package for ISO 639 language codes,
+    names, and other associated information.
+  dev_url: https://github.com/jacksonllee/iso639
+  doc_url: https://github.com/jacksonllee/iso639/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-    sha256: 97e63b5603e085c6a56a12a95740010e75d9134e0aab767e0978b53fd8824f13
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 97e63b5603e085c6a56a12a95740010e75d9134e0aab767e0978b53fd8824f13
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 97e63b5603e085c6a56a12a95740010e75d9134e0aab767e0978b53fd8824f13
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+    sha256: 97e63b5603e085c6a56a12a95740010e75d9134e0aab767e0978b53fd8824f13
+  # file needed for tests, not included in the pypi tarball
+  - url: https://raw.githubusercontent.com/jacksonllee/iso639/v{{ version }}/CHANGELOG.md
+    sha256: 8f8da6ba0cce1e1e2065a1082c74f0e5d7144d18de050efd13552fa552d53746
 
 build:
   number: 0
@@ -26,12 +29,15 @@ requirements:
 test:
   imports:
     - iso639
-  commands:
-    - pip check
-  source_files:
-    - tests
   requires:
     - pip
+    - pytest
+  source_files:
+    - tests
+    - CHANGELOG.md
+  commands:
+    - pip check
+    - pytest -vv --durations=0 --strict-markers tests
 
 about:
   home: https://github.com/jacksonllee/iso639

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,6 @@ package:
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
     sha256: 97e63b5603e085c6a56a12a95740010e75d9134e0aab767e0978b53fd8824f13
-  # file needed for tests, not included in the pypi tarball
-  - url: https://raw.githubusercontent.com/jacksonllee/iso639/v{{ version }}/CHANGELOG.md
-    sha256: 8f8da6ba0cce1e1e2065a1082c74f0e5d7144d18de050efd13552fa552d53746
 
 build:
   number: 0
@@ -34,12 +31,14 @@ test:
     - pytest
   source_files:
     - tests
-    - CHANGELOG.md
   commands:
     - pip check
-    # see section tool.pytest.ini_options in pyproject.toml for the
-    # additional parameters
-    - pytest -vv --durations=0 --strict-markers tests
+    # the additional parameters in the section tool.pytest.ini_options
+    # in pyproject.toml for the are not actually used by the tests
+    # 
+    # skip test_version_number_match_with_changelog because it uses
+    # the file CHANGELOG.md which is not included in the archive
+    - pytest -v tests -k "not test_version_number_match_with_changelog"
 
 about:
   home: https://github.com/jacksonllee/iso639

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,8 @@ test:
     - CHANGELOG.md
   commands:
     - pip check
+    # see section tool.pytest.ini_options in pyproject.toml for the
+    # additional parameters
     - pytest -vv --durations=0 --strict-markers tests
 
 about:


### PR DESCRIPTION
python-iso639 2024.4.27 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5175]
- dev_url (pypi): https://github.com/jacksonllee/iso639/tree/v2024.4.27
- conda-forge: https://github.com/conda-forge/python-iso639-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/python-iso639/2024.4.27
- pypi inspector: https://inspector.pypi.io/project/python-iso639/2024.4.27

### Explanation of changes:

- new feedstock
- add upstream tests
- ~source `CHANGELOG.md` directly from GH because not in the PyPi tarball and needed for 1 test.~ that test skipped


[PKG-5175]: https://anaconda.atlassian.net/browse/PKG-5175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ